### PR TITLE
Fix redis hostnames when setting a helm release name

### DIFF
--- a/deploy/helm-chart/kube-mail/templates/_helpers.tpl
+++ b/deploy/helm-chart/kube-mail/templates/_helpers.tpl
@@ -78,7 +78,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the Redis hostname
 */}}
 {{- define "chart.redis.host" -}}
-{{- ternary (printf "%s-redis" (include "chart.fullname" .)) .Values.externalRedis.host .Values.redis.enabled -}}
+{{- ternary (printf "%s-redis" .Release.Name ) .Values.externalRedis.host .Values.redis.enabled -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm-chart/kube-mail/templates/deployment.yaml
+++ b/deploy/helm-chart/kube-mail/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
               value: {{ .Values.redis.sentinel.masterSet | quote }}
             {{- else }}
             - name: KUBEMAIL_REDIS_HOST
-              value: {{ include "chart.redis.host" . }}
+              value: {{ include "chart.redis.host" . }}-master
             - name: KUBEMAIL_REDIS_PORT
               value: {{ include "chart.redis.port" . | quote }}
             {{- end }}

--- a/deploy/helm-chart/kube-mail/templates/deployment.yaml
+++ b/deploy/helm-chart/kube-mail/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             {{- end }}
             {{- if .Values.redis.sentinel.enabled }}
             - name: KUBEMAIL_REDIS_SENTINEL_HOST
-              value: {{ template "chart.fullname" . }}-redis
+              value: {{ include "chart.redis.host" . }}
             - name: KUBEMAIL_REDIS_SENTINEL_PORT
               value: {{ .Values.redis.sentinel.port | quote }}
             - name: KUBEMAIL_REDIS_SENTINEL_MASTERSET

--- a/deploy/helm-chart/kube-mail/values.yaml
+++ b/deploy/helm-chart/kube-mail/values.yaml
@@ -94,5 +94,5 @@ redis:
     enabled: true
     allowExternal: false
 externalRedis:
-  # port:
-  # host:
+  port:
+  host:


### PR DESCRIPTION
The redis hostnames aren't correctly configured if the helm release name is set to anything else than "kube-mail", which kinda-defeats the point of having helm release names.